### PR TITLE
feat!: upgrade to Angular 21 (v7.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# 7.0.0 (2026-05-20)
+
+### Bug Fixes
+
+* none
+
+### Features
+
+* Upgraded to Angular 21 (21.2.x).
+* Updated library peer dependencies (`@angular/common`, `@angular/core`, `@angular/forms`) to `^21.0.0`.
+* Bumped `@angular/cli` and `@angular-devkit/build-angular` to `~21.2.11` / `^21.2.11`.
+* Bumped `ng-packagr` to `^21.2.3`.
+* Bumped `typescript` to `~5.9.3` (Angular 21 supported range `>=5.9 <6.0`).
+* `zone.js` stays on `~0.15.1` (still supported by Angular 21).
+* `angular-eslint` (`21.4.0`) and `typescript-eslint` (`8.59.4`) unchanged.
+
+### Breaking Changes
+
+* Peer dependencies now require `@angular/common`, `@angular/core` and `@angular/forms` at `^21.0.0`.
+* Minimum supported Node.js is now `^20.19.0 || ^22.12.0 || >=24.0.0` (Angular 21 requirement).
+* TypeScript `>=5.9 <6.0` is required (Angular 21 requirement).
+
+
 # 6.0.1 (2026-05-20)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Online demo is [here](http://kekeh.github.io/angular-mydatepicker)
 
 ### Project
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) and is currently built against __Angular 20__ (CLI 20.3.x).
+This project was generated with [Angular CLI](https://github.com/angular/angular-cli) and is currently built against __Angular 21__ (CLI 21.2.x). See the [CHANGELOG](./CHANGELOG.md) for the full upgrade history.
 
-Source code of the component is in the [projects/angular-mydatepicker/src](https://github.com/kekeh/angular-mydatepicker/tree/master/projects/angular-mydatepicker/src) folder.
+Source code of the component is in the [projects/angular-mydatepicker/src](https://github.com/BAXTER-IT/trade-datepicker/tree/master/projects/angular-mydatepicker/src) folder.
 
 
 ## Code examples
@@ -424,10 +424,10 @@ Usage examples of the __stylesData__ option:
 In order the following commands work you need a __git client__ and __npm__.
 
 * At first fork and clone this repo:
-  1. __git clone https://github.com/kekeh/angular-mydatepicker.git__
+  1. __git clone https://github.com/BAXTER-IT/trade-datepicker__
   2. __cd angular-mydatepicker__
 
-* Install tools (version >= 20.3):
+* Install tools (version >= 21.2):
   1. __npm install --g @angular/cli__
 
 * Install dependencies:
@@ -458,11 +458,21 @@ In order the following commands work you need a __git client__ and __npm__.
 ## Demo
 Online demo is [here](http://kekeh.github.io/angular-mydatepicker)
 
+## Changelog
+
+Release notes for every version are tracked in [CHANGELOG.md](./CHANGELOG.md).
+
+Recent highlights:
+- **v7.0.0** — Upgraded to **Angular 21** (21.2.x). Peer deps now require `@angular/* ^21.0.0`. Requires Node `^20.19.0 || ^22.12.0 || >=24.0.0` and TypeScript `>=5.9 <6.0`.
+- **v6.0.0** — Library converted to **standalone** components/directives; `AngularMyDatePickerModule` removed.
+- **v5.0.0** — Upgraded to **Angular 20** (20.3.x).
+
 ## License
 * [MIT](https://github.com/kekeh/angular-mydatepicker/blob/master/LICENSE)
 
 ## Author
 * kekeh
+* mrobix
 
 ## Keywords
 * datepicker

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade-datepicker",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "description": "Angular datepicker and date range picker",
   "keywords": [
     "Angular",
@@ -25,24 +25,24 @@
   },
   "private": false,
   "dependencies": {
-    "@angular/animations": "~20.3.21",
-    "@angular/common": "~20.3.21",
-    "@angular/compiler": "~20.3.21",
-    "@angular/core": "~20.3.21",
-    "@angular/forms": "~20.3.21",
-    "@angular/platform-browser": "~20.3.21",
-    "@angular/platform-browser-dynamic": "~20.3.21",
-    "@angular/router": "~20.3.21",
+    "@angular/animations": "~21.2.13",
+    "@angular/common": "~21.2.13",
+    "@angular/compiler": "~21.2.13",
+    "@angular/core": "~21.2.13",
+    "@angular/forms": "~21.2.13",
+    "@angular/platform-browser": "~21.2.13",
+    "@angular/platform-browser-dynamic": "~21.2.13",
+    "@angular/router": "~21.2.13",
     "core-js": "^3.30.1",
     "rollup": "^3.20.6",
     "rxjs": "~7.8.0",
     "zone.js": "~0.15.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^20.3.26",
-    "@angular/cli": "~20.3.26",
-    "@angular/compiler-cli": "~20.3.21",
-    "@angular/language-service": "~20.3.21",
+    "@angular-devkit/build-angular": "^21.2.11",
+    "@angular/cli": "~21.2.11",
+    "@angular/compiler-cli": "~21.2.13",
+    "@angular/language-service": "~21.2.13",
     "@types/jasmine": "~4.3.1",
     "@types/node": "^20.11.0",
     "angular-eslint": "21.4.0",
@@ -55,10 +55,10 @@
     "karma-coverage": "~2.2.1",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "^2.0.0",
-    "ng-packagr": "^20.3.2",
+    "ng-packagr": "^21.2.3",
     "ts-node": "^10.9.2",
     "tslib": "^2.0.0",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.3",
     "typescript-eslint": "8.59.4"
   }
 }

--- a/projects/angular-mydatepicker/package.json
+++ b/projects/angular-mydatepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade-datepicker",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "description": "Angular datepicker and date range picker",
   "homepage": "https://kekeh.github.io/angular-mydatepicker/",
   "keywords": [
@@ -15,8 +15,8 @@
     "url": "trade-datepicker"
   },
   "peerDependencies": {
-    "@angular/common": "^20.0.0",
-    "@angular/core": "^20.0.0",
-    "@angular/forms": "^20.0.0"
+    "@angular/common": "^21.0.0",
+    "@angular/core": "^21.0.0",
+    "@angular/forms": "^21.0.0"
   }
 }


### PR DESCRIPTION
Upgrade the library and workspace to Angular 21 (21.2.x):

- Bump `@angular/*` packages to `~21.2.13` and CLI/build tooling to `~21.2.11` / `^21.2.11`
- Bump `@angular/compiler-cli` and `@angular/language-service` to `~21.2.13`, and `ng-packagr` to `^21.2.3`
- Require TypeScript `~5.9.3` (Angular 21 supports `>=5.9 <6.0`)
- Update library peer dependencies (`@angular/common`, `@angular/core`, `@angular/forms`) to `^21.0.0`
- Bump package version to `7.0.0` and document the upgrade in CHANGELOG.md and README.md

BREAKING CHANGE: Consumers must now use `@angular/* ^21.0.0`, Node `^20.19.0 || ^22.12.0 || >=24.0.0`, and TypeScript `>=5.9 <6.0`.